### PR TITLE
Support for msvcrt.strlen

### DIFF
--- a/speakeasy/winenv/api/usermode/msvcrt.py
+++ b/speakeasy/winenv/api/usermode/msvcrt.py
@@ -301,6 +301,16 @@ class Msvcrt(api.ApiHandler):
 
         return z
 
+    @apihook('strlen', argc=1)
+    def strlen(self, emu, argv, ctx={}):
+        '''
+        size_t strlen(  
+          const char *str  
+        );
+        '''
+        _str, = argv
+        return(len(self.read_string(_str)))    
+    
     @apihook('strstr', argc=2, conv=e_arch.CALL_CONV_CDECL)
     def strstr(self, emu, argv, ctx={}):
         """


### PR DESCRIPTION
First commit on this project, starting with an easy one.  

This is support for `msvcrt.strlen`. 

I tested it on sample `a8068055457daa6a9b15f469e39f9138` with the following log below.

```
0x401014: 'MSVCRT.memset(0x41d84c, 0x0, 0x24)' -> 0x41d84c
0x401021: 'KERNEL32.GetModuleHandleA(0x0)' -> 0x400000
0x40103a: 'KERNEL32.HeapCreate(0x0, 0x1000, 0x0)' -> 0x40b0
0x409be2: 'KERNEL32.HeapCreate(0x0, 0x1000, 0x0)' -> 0x40d0
0x409c10: 'KERNEL32.HeapAlloc(0x40d0, 0x0, 0x10)' -> 0x40f0
0x409324: 'MSVCRT.memset(0x41d89c, 0x0, 0x30)' -> 0x41d89c
0x409cea: 'MSVCRT.strlen(0x40c033)' -> 0x6
0x409d0d: 'KERNEL32.HeapAlloc(0x40d0, 0x0, 0xb)' -> 0x4110
0x409c93: 'MSVCRT.strlen(0x4110)' -> 0x6
0x409caf: 'KERNEL32.HeapAlloc(0x40d0, 0x0, 0xb)' -> 0x4120
0x409cea: 'MSVCRT.strlen(0x40c02b)' -> 0x7
0x409d0d: 'KERNEL32.HeapAlloc(0x40d0, 0x0, 0xc)' -> 0x4130
0x40204a: 'KERNEL32.GlobalAlloc(0x0, 0x14)' -> 0x4140
0x40a18e: 'MSVCRT.memcpy(0x4140, 0x4130, 0x7)' -> 0x4140
Caught error: unsupported_api
Invalid memory read (UC_ERR_READ_UNMAPPED)
Unsupported API: KERNEL32.GlobalFree
* Finished emulating
```

Any additional guidance or tips are always appreciated. 