### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@
 
 import setuptools
 
-with open('README.md', 'r') as fh:
+with open('README.md', 'r', encoding='utf8') as fh:
     long_description = fh.read()
 
-with open("speakeasy/version.py") as fp:
+with open("speakeasy/version.py", encoding='utf8') as fp:
     vl = fp.readline()
     gv, ver_num = vl.split('=')
     if gv.strip() != '__version__':


### PR DESCRIPTION
Added encoding='utf8' to avoid "'ascii' codec can't decode byte" errors when trying to run setup.py using SaltStack or trying to install the tool in Docker where LANG might not be defined. Without this, the tool doesn't install via SaltStack, and I cannot add it to REMnux.