### PR TITLE
Adding support for msvcrt.wcslen

### DIFF
--- a/speakeasy/winenv/api/usermode/msvcrt.py
+++ b/speakeasy/winenv/api/usermode/msvcrt.py
@@ -747,6 +747,20 @@ class Msvcrt(api.ApiHandler):
 
         return rv
 
+    @apihook('wcslen', argc=1, conv=e_arch.CALL_CONV_CDECL)
+    def wcslen(self, emu, argv, ctx={}):
+        """
+        size_t wcslen(
+          const wchar_t* wcs
+        );
+        """
+        s, = argv
+        string = self.read_wide_string(s)
+        argv[0] = string
+        rv = len(string)
+        
+        return rv
+    
     @apihook('_lock', argc=1, conv=e_arch.CALL_CONV_CDECL)
     def _lock(self, emu, argv, ctx={}):
         """


### PR DESCRIPTION
Another simple PR to get coverage on `wcslen`.  I largely borrowed from the implementation of strlen that is right above it.

I also noticed that there are 2 implementations of `strlen`, I put in a PR for one (which can probably be deleted now) and the other one looks like it got added tonight.  