### PR TITLE
Adding support for msvcrt.strncpy

### DIFF
--- a/speakeasy/winenv/api/usermode/msvcrt.py
+++ b/speakeasy/winenv/api/usermode/msvcrt.py
@@ -548,7 +548,24 @@ class Msvcrt(api.ApiHandler):
         self.write_string(s, dest)
         argv[1] = s
         return len(s)
-
+    
+    @apihook('strncpy', argc=3, conv=e_arch.CALL_CONV_CDECL)
+    def strncpy(self, emu, argv, ctx={}):
+        """
+        char * strncpy( 
+            char * destination, 
+            const char * source, 
+            size_t num 
+        );
+        """
+        dest, src, length = argv
+        s = self.read_string(src,max_chars=length)
+        if len(s) < length:
+            s += '\x00'*(length-len(s))
+        self.write_string(s, dest)
+        argv[1] = s
+        return dest
+    
     @apihook('memcpy', argc=3, conv=e_arch.CALL_CONV_CDECL)
     def memcpy(self, emu, argv, ctx={}):
         """


### PR DESCRIPTION
Adding support for strncpy.  

I did have a question on this commit.  

According to the MSDN documentation on strncpy: `If count is greater than the length of strSource, the destination string is padded with null characters up to length count. `

So I have accounted for this in 
```
s += '\x00'*(size-len(s))
```

The method that writes the string to memory is `self.write_string(s, dest)`.  Is `write_string` going to truncate the string at the null or write the entire string?

Thanks for the help.