### PR TITLE
Adding support for user32.GetKeyboardType

### DIFF
--- a/speakeasy/winenv/api/usermode/user32.py
+++ b/speakeasy/winenv/api/usermode/user32.py
@@ -227,7 +227,23 @@ class User32(api.ApiHandler):
 
         rv = 0
         return rv
-
+    
+    @apihook('GetKeyboardType', argc=1)
+    def GetKeyboardType(self, emu, argv, ctx={}):
+        '''
+        int GetKeyboardType(
+          int nTypeFlag
+        );
+        '''
+        _type, = argv
+        if _type == 0:
+            return 4
+        elif _type == 1:
+            return 0
+        elif _type == 2:
+            return 12
+        return 0
+    
     @apihook('GetSystemMetrics', argc=1)
     def GetSystemMetrics(self, emu, argv, ctx={}):
         """


### PR DESCRIPTION
For this I largely borrowed from qiling's implementation.  I changed the keyboard to default to  `IBM enhanced (101- or 102-key) keyboard` rather than ` Japanese keyboard `

https://github.com/qilingframework/qiling/blob/078996ce2dbe61c3da0b9b352634876d0e38be0f/qiling/os/windows/dlls/user32.py#L559