### PR TITLE
redirect winsock and wsock32 to ws2_32.dll

### DIFF
--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -983,6 +983,10 @@ class WindowsEmulator(BinaryEmulator):
         if (dll.lower().startswith(('api-ms-win-crt', 'vcruntime', 'ucrtbased'))):
             alt_imp_dll = 'msvcrt'
 
+        # Redirect windows sockets 1.0 to windows sockets 2.0
+        if (dll.lower().startswith('winsock') or dll.lower().startswith('wsock32')):
+            alt_imp_dll = 'ws2_32'
+
         # Bridge ntdll funcs to ntoskrnl if supported
         elif dll.lower().startswith('ntdll'):
             alt_imp_dll = 'ntoskrnl'


### PR DESCRIPTION
This change redirects winsocks 1.0 API calls from winsock and wsock32 dlls to ws2_32.dll (2.0 API).
Let me know if this isn't the planned way to deal with this.