### PR TITLE
Add support for kernel32.GetThreadLocale

### DIFF
--- a/speakeasy/winenv/api/usermode/kernel32.py
+++ b/speakeasy/winenv/api/usermode/kernel32.py
@@ -146,6 +146,13 @@ class Kernel32(api.ApiHandler):
 
         return None
 
+    @apihook('GetThreadLocale', argc=0)
+    def GetThreadLocale(self, emu, argv, ctx={}):
+        '''
+        LCID GetThreadLocale();
+        '''
+        return 0xC000
+    
     @apihook('OutputDebugString', argc=1)
     def OutputDebugString(self, emu, argv, ctx={}):
         '''


### PR DESCRIPTION
This is a simple PR adding in support for GetThreadLocale 

The constant returned is for LOCALE_CUSTOM_DEFAULT `0xC000` 

https://docs.microsoft.com/en-us/windows/win32/intl/locale-custom-constants