### PR TITLE
Update user32.py

### DIFF
--- a/speakeasy/winenv/api/usermode/user32.py
+++ b/speakeasy/winenv/api/usermode/user32.py
@@ -731,3 +731,24 @@ class User32(api.ApiHandler):
         argv[1] = cchLength
         self.write_mem_string(val.upper(), _str, cw)
         return cchLength
+
+    @apihook('CharLower', argc=1)
+    def CharLower(self, emu, argv, ctx={}):
+        """
+        LPSTR CharLowerA(
+            LPSTR lpsz
+        );
+        """
+        _str, = argv
+        cw = self.get_char_width(ctx)
+        bits = _str.bit_length()
+        if bits <= 16:
+            if cw == 1:
+                val = chr(_str).lower().encode('ascii')
+            else:
+                val = chr(_str).lower().encode('utf-16le')
+            return int.from_bytes(val, byteorder='little')
+        else:
+            val = self.read_mem_string(_str, cw)
+            self.write_mem_string(val.lower(), _str, cw)
+            return _str    


### PR DESCRIPTION
This PR adds support for `CharLower` in `user32`.

According to the docs (https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-charlowera) CharLower can take either a pointer to a string or a value and return back the lowercase string or value (the string being converted in place).  I wasn't sure the best method of determining if something was a pointer or value in Speakeasy so I used `bit_length` to look for a single char (either ascii or unicode).

Let me know if anything needs to be changed.

