### PR TITLE
Update ntdll.py

### DIFF
--- a/speakeasy/winenv/api/usermode/ntdll.py
+++ b/speakeasy/winenv/api/usermode/ntdll.py
@@ -166,3 +166,15 @@ class Ntdll(api.ApiHandler):
                 self.mem_write(func_addr, addr.to_bytes(self.get_ptr_size(), 'little'))
 
         return rv
+
+    @apihook('RtlZeroMemory', argc=2)
+    def RtlZeroMemory(self, emu, argv, ctx={}):
+        """
+        void RtlZeroMemory(
+            void*  Destination,
+            size_t Length
+        );
+        """
+        dest,length = argv
+        buf = b'\x00' * length
+        self.mem_write(dest, buf)


### PR DESCRIPTION
Adding `RtlZeroMemory`

This can be tested with `fa5faef03bad26cfe27ddd2935cc35ab4fdf129c4a17221dedc05de81b1d9422`

Using the documentation from here -> https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlzeromemory