### PR TITLE
Update kernel32.py

### DIFF
--- a/speakeasy/winenv/api/usermode/kernel32.py
+++ b/speakeasy/winenv/api/usermode/kernel32.py
@@ -4108,3 +4108,15 @@ class Kernel32(api.ApiHandler):
         pfnAPC, hThread, dwData = argv
         run_type = 'apc_thread_%x' % hThread
         self.create_thread(pfnAPC, dwData, 0, thread_type=run_type)
+
+    @apihook('RtlZeroMemory', argc=2)
+    def RtlZeroMemory(self, emu, argv, ctx={}):
+        """
+        void RtlZeroMemory(
+            void*  Destination,
+            size_t Length
+        );
+        """
+        dest,length = argv
+        buf = b'\x00' * length
+        self.mem_write(dest, buf)


### PR DESCRIPTION
Also realized that RtlZeroMemory appears within Kernel32 as well.

This can be tested with `d52ef63fdc5c5452d9da23bd6d4bf0f5`.  It's using the same implementation as ntdll.