### PR TITLE
Initial API hammering mitigation

### DIFF
--- a/speakeasy/config_schema.json
+++ b/speakeasy/config_schema.json
@@ -212,6 +212,24 @@
                 "name"
             ]
         },
+        "api_hammering": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Controls whether API hammering mitigation is used or not"
+                },
+                "threshold": {
+                    "type": "number",
+                    "description": "Threshold for an individual API call to trigger API hammer mitigation"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "enabled", 
+                "threshold"
+            ]
+        },
         "symlinks": {
             "type": "array",
             "description": "Lists symbolic links to present to the emulated sample",

--- a/speakeasy/configs/default.json
+++ b/speakeasy/configs/default.json
@@ -45,6 +45,11 @@
         "is_admin": true
     },
 
+    "api_hammering": {
+        "enabled": false,
+        "threshold": 2000
+    },
+
     "symlinks": [
         {
             "name": "\\??\\C:",

--- a/speakeasy/configs/win10_basic_analysis.json
+++ b/speakeasy/configs/win10_basic_analysis.json
@@ -36,6 +36,11 @@
         "name": "user"
     },
 
+    "api_hammering": {
+        "enabled": false,
+        "threshold": 2000
+    },
+
     "symlinks": [
         {
             "name": "\\??\\C:",

--- a/speakeasy/configs/win10_full_analysis.json
+++ b/speakeasy/configs/win10_full_analysis.json
@@ -36,6 +36,11 @@
         "name": "user"
     },
 
+    "api_hammering": {
+        "enabled": false,
+        "threshold": 2000
+    },
+
     "symlinks": [
         {
             "name": "\\??\\C:",

--- a/speakeasy/configs/win7_full_analysis.json
+++ b/speakeasy/configs/win7_full_analysis.json
@@ -36,6 +36,11 @@
         "name": "user"
     },
 
+    "api_hammering": {
+        "enabled": false,
+        "threshold": 2000
+    },
+
     "symlinks": [
         {
             "name": "\\??\\C:",

--- a/speakeasy/windows/hammer.py
+++ b/speakeasy/windows/hammer.py
@@ -1,0 +1,93 @@
+import collections
+
+import speakeasy.winenv.arch as e_arch
+
+# When disassembling, a minimum instruction size needs to be supplied
+# This number is arbitrary and just needs to be large enough to cover
+# the size of the current disasm target
+DISASM_SIZE = 0x20
+
+
+
+
+class ApiHammer():
+    """
+    """
+
+    def __init__(self, emu):
+        super(ApiHammer, self).__init__()
+        self.emu = emu
+        self.api_stats = collections.defaultdict(int)
+        self.hammer_memregion = None
+        self.hammer_offset = 0
+
+        # default enabled for now until configs are updated
+        self.config = self.emu.config.get('api_hammering', {})
+        self.api_threshold = self.config.get('threshold', 1000)
+        self.enabled = self.config.get('enabled', True)
+
+    def handle_import_func(self, imp_api, conv, argc):
+        '''
+        Identifies possible API hammering and attempts to patch in mitigations.
+        '''
+        if not self.enabled:
+            return
+        hammer_key = imp_api + '%x' % self.emu.get_ret_address()
+        self.api_stats[hammer_key] += 1
+        if self.api_stats[hammer_key] < self.api_threshhold:
+            return
+        self.emu.log_info('api hammering at: 0x%x 0x%x' % (self.emu.get_pc(), self.emu.get_ret_address()) )
+        # TODO: better parameterize the checking & dispatch of the types of calls/jmps to imports
+        # so we can more easily loop through them & clean up the the logic below
+        # TODO: track patches in the hammer_memregion & reuse when possible
+        if self.emu.get_arch() == e_arch.ARCH_X86:
+            eip = self.emu.get_ret_address() - 6
+            mnem, op, instr = self.emu.get_disasm(eip, DISASM_SIZE)
+            self.emu.log_info('api hammering at: 0x%x %r %r %r' % (self.emu.get_pc(), mnem, op, instr) )
+            if (mnem == 'call') and 'dword ptr' in instr:
+                if conv == e_arch.CALL_CONV_CDECL:
+                    # If cdecl, the emu engine will clean the stack
+                    # just xor eax,eax & 4 bytes of nop 
+                    patch = b'\x31\xc0\x90\x90\x90\x90\x90'
+                    self.emu.mem_write(eip, patch)
+                    self.emu.log_info('API HAMMERING DETECTED - patching 1 cdecl at %x' % (eip, ))
+                elif conv == e_arch.CALL_CONV_STDCALL:
+                    # If stdcall, we need to clean the stack
+                    # patch is xor eax, eax; add esp, <count>
+                    patch = b'\x31\xc0\x83\xc4' + (4*argc).to_bytes(1, 'little') + b'\x90'
+                    self.emu.mem_write(eip, patch)
+                    self.emu.log_info('API HAMMERING DETECTED - patching 1 stdcall at %x' % (eip, ))
+            else:
+                eip = self.emu.get_ret_address() - 2
+                mnem, op, instr = self.emu.get_disasm(eip, DISASM_SIZE)
+                self.emu.log_info('api hammering at: 0x%x %r %r %r' % (self.emu.get_pc(), mnem, op, instr) )
+                if (mnem == 'call') and op in e_arch.REG_LOOKUP.keys():
+                    # not enough space to clean up stack inline, so write stack cleanup code to a hammerpatch
+                    # region & change the register to point to this cleanup code instead
+                    # the hope is that we're in a tight loop, so this will prevent exiting the emulator the
+                    # majority of the time.
+                    if self.hammer_memregion is None:
+                        self.hammer_memregion = self.emu.mem_map(0x1024*4, tag='speakeasy.hammerpatch')
+                    if conv == e_arch.CALL_CONV_CDECL:
+                        # If cdecl, the emu engine will clean the stack
+                        # just xor eax,eax; retn
+                        patch = b'\x31\xc0\xc3'
+                        self.emu.mem_write(eip, patch)
+                        self.emu.log_info('API HAMMERING DETECTED - patching 2 cdecl at %x' % (eip, ))
+                    elif conv == e_arch.CALL_CONV_STDCALL:
+                        # patch is xor eax, eax; retn <count>
+                        patch = b'\x31\xc0\xc2' + (4*argc).to_bytes(2, 'little') + b'\x90'
+                        loc = self.hammer_memregion + self.hammer_offset
+                        if (self.hammer_offset + len(patch)) < 0x1024*4:
+                            self.emu.mem_write(loc, patch)
+                            self.hammer_offset += len(patch)
+                            # now change the the register
+                            reg = e_arch.REG_LOOKUP[op]
+                            self.emu.reg_write(reg, loc)
+                            self.emu.log_info('API HAMMERING DETECTED - patching 2 stdcall at %x' % (eip, ))
+                else:
+                    self.emu.log_info('API HAMMERING DETECTED - unable to patch %x' % (eip, ))
+
+        if self.emu.get_arch() == e_arch.ARCH_AMD64:
+            # TODO
+            pass

--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -16,6 +16,7 @@ from speakeasy.windows.regman import RegistryManager
 from speakeasy.windows.fileman import FileManager
 from speakeasy.windows.cryptman import CryptoManager
 from speakeasy.windows.netman import NetworkManager
+from speakeasy.windows.hammer import ApiHammer
 
 import speakeasy.winenv.defs.nt.ddk as ddk
 import speakeasy.winenv.defs.windows.windows as windef
@@ -98,6 +99,7 @@ class WindowsEmulator(BinaryEmulator):
         self.fileman = FileManager(self.get_filesystem_config())
         self.netman = NetworkManager(config=self.get_network_config())
         self.cryptman = CryptoManager()
+        self.hammer = ApiHammer(self)
 
     def _parse_config(self, config):
         """
@@ -1068,6 +1070,7 @@ class WindowsEmulator(BinaryEmulator):
             imp_api = '%s.%s' % (dll, name)
             default_ctx = {'func_name': imp_api}
 
+            self.hammer.handle_import_func(imp_api, conv, argc)
             hook = self.get_api_hook(dll, name)
             if hook:
                 from types import MethodType

--- a/speakeasy/winenv/api/usermode/gdi32.py
+++ b/speakeasy/winenv/api/usermode/gdi32.py
@@ -82,3 +82,70 @@ class GDI32(api.ApiHandler):
         );
         """
         return 16
+
+    @apihook('GdiSetBatchLimit', argc=1)
+    def GdiSetBatchLimit(self, emu, argv, ctx={}):
+        """
+        DWORD GdiSetBatchLimit(
+          DWORD dw
+        );
+        """
+        return 0
+
+    @apihook('MaskBlt', argc=12)
+    def MaskBlt(self, emu, argv, ctx={}):
+        """
+        BOOL MaskBlt(
+          HDC     hdcDest,
+          int     xDest,
+          int     yDest,
+          int     width,
+          int     height,
+          HDC     hdcSrc,
+          int     xSrc,
+          int     ySrc,
+          HBITMAP hbmMask,
+          int     xMask,
+          int     yMask,
+          DWORD   rop
+        );
+        """
+        return 1
+
+    @apihook('SelectObject', argc=2)
+    def SelectObject(self, emu, argv, ctx={}):
+        """
+        HGDIOBJ SelectObject(
+          HDC     hdc,
+          HGDIOBJ h
+        );
+        """
+        return 0
+
+    @apihook('GetTextCharacterExtra', argc=1)
+    def GetTextCharacterExtra(self, emu, argv, ctx={}):
+        """
+        int GetTextCharacterExtra(
+          HDC hdc
+        );
+        """
+        return 0x8000000
+
+    @apihook('StretchBlt', argc=11)
+    def StretchBlt(self, emu, argv, ctx={}):
+        """
+        BOOL StretchBlt(
+          HDC   hdcDest,
+          int   xDest,
+          int   yDest,
+          int   wDest,
+          int   hDest,
+          HDC   hdcSrc,
+          int   xSrc,
+          int   ySrc,
+          int   wSrc,
+          int   hSrc,
+          DWORD rop
+        );
+        """
+        return 0

--- a/speakeasy/winenv/api/usermode/kernel32.py
+++ b/speakeasy/winenv/api/usermode/kernel32.py
@@ -2892,6 +2892,28 @@ class Kernel32(api.ApiHandler):
 
         return low
 
+    @apihook('GetFileSizeEx', argc=2)
+    def GetFileSizeEx(self, emu, argv, ctx={}):
+        '''
+        BOOL GetFileSizeEx(
+          HANDLE         hFile,
+          PLARGE_INTEGER lpFileSize
+        );
+        '''
+        hFile, lpFileSize = argv
+        f = self.file_get(hFile)
+
+        if f:
+            full_size = f.get_size()
+            size_bytes = full_size.to_bytes(8, 'little')
+            if lpFileSize:
+                self.mem_write(lpFileSize, size_bytes)
+            emu.set_last_error(windefs.ERROR_SUCCESS)
+            return 1
+        emu.set_last_error(windefs.ERROR_INVALID_PARAMETER)
+        return 0
+
+
     @apihook('CloseHandle', argc=1)
     def CloseHandle(self, emu, argv, ctx={}):
         '''
@@ -4019,3 +4041,123 @@ class Kernel32(api.ApiHandler):
         pfnAPC, hThread, dwData = argv
         run_type = 'apc_thread_%x' % hThread
         self.create_thread(pfnAPC, dwData, 0, thread_type=run_type)
+
+
+    @apihook('GetThreadTimes', argc=5)
+    def GetThreadTimes(self, emu, argv, ctx={}):
+        """
+        BOOL GetThreadTimes(
+          HANDLE     hThread,
+          LPFILETIME lpCreationTime,
+          LPFILETIME lpExitTime,
+          LPFILETIME lpKernelTime,
+          LPFILETIME lpUserTime
+        );
+        """
+        return 0
+
+    @apihook('DuplicateHandle', argc=7)
+    def DuplicateHandle(self, emu, argv, ctx={}):
+        """
+        BOOL DuplicateHandle(
+          HANDLE   hSourceProcessHandle,
+          HANDLE   hSourceHandle,
+          HANDLE   hTargetProcessHandle,
+          LPHANDLE lpTargetHandle,
+          DWORD    dwDesiredAccess,
+          BOOL     bInheritHandle,
+          DWORD    dwOptions
+        )
+        """
+        return 0
+
+    @apihook('GetBinaryType', argc=2)
+    def GetBinaryType(self, emu, argv, ctx={}):
+        """
+        BOOL GetBinaryTypeA(
+          LPCSTR  lpApplicationName,
+          LPDWORD lpBinaryType
+        );
+        """
+        return 0
+
+
+    @apihook('GetThreadUILanguage', argc=0)
+    def GetThreadUILanguage(self, emu, argv, ctx={}):
+        """
+        LANGID GetThreadUILanguage();
+        """
+        return 0xffff
+
+    @apihook('SetConsoleHistoryInfo', argc=1)
+    def SetConsoleHistoryInfo(self, emu, argv, ctx={}):
+        """
+        BOOL WINAPI SetConsoleHistoryInfo(
+          _In_ PCONSOLE_HISTORY_INFO lpConsoleHistoryInfo
+        );
+        """
+        return 1
+
+
+    @apihook('GetFileInformationByHandle', argc=2)
+    def GetFileInformationByHandle(self, emu, argv, ctx={}):
+        """
+        BOOL GetFileInformationByHandle(
+          HANDLE                       hFile,
+          LPBY_HANDLE_FILE_INFORMATION lpFileInformation
+        );
+        """
+        return 0
+
+    @apihook('GetCommProperties', argc=2)
+    def GetCommProperties(self, emu, argv, ctx={}):
+        """
+        BOOL GetCommProperties(
+          HANDLE     hFile,
+          LPCOMMPROP lpCommProp
+        );
+        """
+        return 0
+
+    @apihook('GetCommTimeouts', argc=2)
+    def GetCommTimeouts(self, emu, argv, ctx={}):
+        """
+        BOOL GetCommTimeouts(
+          HANDLE         hFile,
+          LPCOMMTIMEOUTS lpCommTimeouts
+        );
+        """
+        return 0
+
+    @apihook('AddAtom', argc=1)
+    def AddAtom(self, emu, argv, ctx={}):
+        """
+        ATOM AddAtomW(
+          LPCWSTR lpString
+        );
+        """
+        return 0
+
+    @apihook('GetProcessHandleCount', argc=1)
+    def GetProcessHandleCount(self, emu, argv, ctx={}):
+        """
+        BOOL GetProcessHandleCount(
+          HANDLE hProcess,
+          PDWORD pdwHandleCount
+        );
+        """
+        return  0
+
+
+    @apihook('GetMailslotInfo', argc=5)
+    def GetMailslotInfo(self, emu, argv, ctx={}):
+        """
+        BOOL GetMailslotInfo(
+          HANDLE  hMailslot,
+          LPDWORD lpMaxMessageSize,
+          LPDWORD lpNextSize,
+          LPDWORD lpMessageCount,
+          LPDWORD lpReadTimeout
+        );
+        """
+        return 0

--- a/speakeasy/winenv/api/usermode/lz32.py
+++ b/speakeasy/winenv/api/usermode/lz32.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2020 FireEye, Inc. All Rights Reserved.
+
+import speakeasy.winenv.defs.windows.windows as windefs
+import speakeasy.winenv.arch as _arch
+
+from .. import api
+
+
+class Lz32(api.ApiHandler):
+
+    name = 'lz32'
+    apihook = api.ApiHandler.apihook
+    impdata = api.ApiHandler.impdata
+
+    def __init__(self, emu):
+
+        super(Lz32, self).__init__(emu)
+        super(Lz32, self).__get_hook_attrs__(self)
+
+    @apihook('LZSeek', argc=3, conv=_arch.CALL_CONV_STDCALL)
+    def LZSeek(self, emu, argv, ctx={}):
+        """
+        LONG LZSeek(
+          INT  hFile,
+          LONG lOffset,
+          INT  iOrigin
+        );
+        """
+        return -1
+
+
+    #@apihook('', argc=3, conv=_arch.CALL_CONV_STDCALL)
+    #def (self, emu, argv, ctx={}):
+    #    """
+
+    #    """
+    #    return 0
+
+
+
+

--- a/speakeasy/winenv/api/usermode/msi32.py
+++ b/speakeasy/winenv/api/usermode/msi32.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2020 FireEye, Inc. All Rights Reserved.
+
+import speakeasy.winenv.defs.windows.windows as windefs
+import speakeasy.winenv.arch as _arch
+
+from .. import api
+
+
+class Msi32(api.ApiHandler):
+
+    name = 'msi32'
+    apihook = api.ApiHandler.apihook
+    impdata = api.ApiHandler.impdata
+
+    def __init__(self, emu):
+
+        super(Msi32, self).__init__(emu)
+        super(Msi32, self).__get_hook_attrs__(self)
+
+    @apihook('MsiDatabaseMergeA', argc=3, conv=_arch.CALL_CONV_STDCALL, ordinal=29)
+    def MsiDatabaseMergeA(self, emu, argv, ctx={}):
+        """
+        UINT MsiDatabaseMergeA(
+          MSIHANDLE hDatabase,
+          MSIHANDLE hDatabaseMerge,
+          LPCSTR    szTableName
+        );
+        """
+        return 0
+
+
+

--- a/speakeasy/winenv/api/usermode/msimg32.py
+++ b/speakeasy/winenv/api/usermode/msimg32.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2020 FireEye, Inc. All Rights Reserved.
+
+import speakeasy.winenv.arch as _arch
+import speakeasy.windows.sessman as sessman
+import speakeasy.winenv.defs.windows.user32 as windefs
+import speakeasy.winenv.defs.windows.windef as windef
+
+from .. import api
+
+class Msimg32(api.ApiHandler):
+
+    """
+    Implements exported functions from msimg.dll
+    """
+
+    name = 'msimg32'
+    apihook = api.ApiHandler.apihook
+    impdata = api.ApiHandler.impdata
+
+    def __init__(self, emu):
+
+        super(Msimg32, self).__init__(emu)
+        super(Msimg32, self).__get_hook_attrs__(self)
+
+    @apihook('TransparentBlt', argc=11)
+    def TransparentBlt(self, emu, argv, ctx={}):
+        '''
+        BOOL TransparentBlt(
+          HDC  hdcDest,
+          int  xoriginDest,
+          int  yoriginDest,
+          int  wDest,
+          int  hDest,
+          HDC  hdcSrc,
+          int  xoriginSrc,
+          int  yoriginSrc,
+          int  wSrc,
+          int  hSrc,
+          UINT crTransparent
+        );
+        '''
+        return 1
+

--- a/speakeasy/winenv/api/usermode/user32.py
+++ b/speakeasy/winenv/api/usermode/user32.py
@@ -3,6 +3,7 @@
 import speakeasy.winenv.arch as _arch
 import speakeasy.windows.sessman as sessman
 import speakeasy.winenv.defs.windows.user32 as windefs
+import speakeasy.winenv.defs.windows.windef as windef
 
 from .. import api
 
@@ -699,3 +700,54 @@ class User32(api.ApiHandler):
         num_devices = 4
         self.mem_write(puiNumDevices, num_devices.to_bytes(4, 'little'))
         return num_devices
+
+
+    @apihook('GetNextDlgTabItem', argc=3)
+    def GetNextDlgTabItem(self, emu, argv, ctx={}):
+        """
+        HWND GetNextDlgTabItem(
+          HWND hDlg,
+          HWND hCtl,
+          BOOL bPrevious
+        );
+        """
+        return 0
+
+    @apihook('GetCaretPos', argc=1)
+    def GetCaretPos(self, emu, argv, ctx={}):
+        """
+        BOOL GetCaretPos(
+          LPPOINT lpPoint
+        );
+        """
+        lpPoint = argv[0]
+        point = windef.POINT(emu.get_ptr_size())
+        point.x = 0
+        point.y = 0
+        self.mem_write(lpPoint, self.get_bytes(point))
+        return 1
+
+    @apihook('GetMonitorInfo', argc=2)
+    def GetMonitorInfo(self, emu, argv, ctx={}):
+        """
+        BOOL GetMonitorInfo(
+          HMONITOR      hMonitor,
+          LPMONITORINFO lpmi
+        );
+        """
+        hMonitor, lpmi = argv
+        mi = windef.MONITORINFO(emu.get_ptr_size())
+        mi = self.mem_cast(mi, lpmi)
+        # just a stub for now
+        self.mem_write(lpmi, self.get_bytes(mi))
+        return 1
+
+    @apihook('EndPaint', argc=2)
+    def EndPaint(self, emu, argv, ctx={}):
+        """
+        BOOL EndPaint(
+          HWND              hWnd,
+          const PAINTSTRUCT *lpPaint
+        );
+        """
+        return 1

--- a/speakeasy/winenv/api/usermode/user32.py
+++ b/speakeasy/winenv/api/usermode/user32.py
@@ -751,3 +751,66 @@ class User32(api.ApiHandler):
         );
         """
         return 1
+
+    @apihook('GetDlgCtrlID', argc=1)
+    def GetDlgCtrlID(self, emu, argv, ctx={}):
+        """
+        int GetDlgCtrlID(
+          HWND hWnd
+        );
+        """
+        return 1
+
+    @apihook('GetUpdateRect', argc=3)
+    def GetUpdateRect(self, emu, argv, ctx={}):
+        """
+        BOOL GetUpdateRect(
+          HWND   hWnd,
+          LPRECT lpRect,
+          BOOL   bErase
+        );
+        """
+        return 0
+
+    @apihook('GetAltTabInfo', argc=5)
+    def GetAltTabInfo(self, emu, argv, ctx={}):
+        """
+        BOOL GetAltTabInfoA(
+          HWND        hwnd,
+          int         iItem,
+          PALTTABINFO pati,
+          LPSTR       pszItemText,
+          UINT        cchItemText
+        );
+        """
+        return 0
+
+    @apihook('GetUpdateRgn', argc=3)
+    def GetUpdateRgn(self, emu, argv, ctx={}):
+        """
+        int GetUpdateRgn(
+          HWND hWnd,
+          HRGN hRgn,
+          BOOL bErase
+        );
+        """
+        return 0
+
+    @apihook('FlashWindow', argc=2)
+    def FlashWindow(self, emu, argv, ctx={}):
+        """
+        BOOL FlashWindow(
+          HWND hWnd,
+          BOOL bInvert
+        );
+        """
+        return 1
+
+    @apihook('IsClipboardFormatAvailable', argc=1)
+    def IsClipboardFormatAvailable(self, emu, argv, ctx={}):
+        """
+        BOOL IsClipboardFormatAvailable(
+          UINT format
+        );
+        """
+        return 0

--- a/speakeasy/winenv/api/winapi.py
+++ b/speakeasy/winenv/api/winapi.py
@@ -6,7 +6,7 @@ from speakeasy.winenv.api.kernelmode import ntoskrnl, hal, wdfldr, netio, ndis, 
 from speakeasy.winenv.api.usermode import ws2_32, kernel32, wininet, winhttp, user32, \
                                           advapi32, msvcrt, wtsapi32, mscoree, dnsapi, \
                                           ntdll, crypt32, shell32, shlwapi, advpack, gdi32, \
-                                          urlmon, ole32, comctl32, msimg32
+                                          urlmon, ole32, comctl32, msimg32, msi32, lz32
 
 API_HANDLERS = (
                     # Kernel mode
@@ -38,6 +38,8 @@ API_HANDLERS = (
                     ('ole32', ole32.Ole32),
                     ('comctl32', comctl32.Comctl32),
                     ('msimg32', msimg32.Msimg32),
+                    ('msi', msi32.Msi32),
+                    ('lz32', lz32.Lz32),
                )
 
 

--- a/speakeasy/winenv/api/winapi.py
+++ b/speakeasy/winenv/api/winapi.py
@@ -6,7 +6,7 @@ from speakeasy.winenv.api.kernelmode import ntoskrnl, hal, wdfldr, netio, ndis, 
 from speakeasy.winenv.api.usermode import ws2_32, kernel32, wininet, winhttp, user32, \
                                           advapi32, msvcrt, wtsapi32, mscoree, dnsapi, \
                                           ntdll, crypt32, shell32, shlwapi, advpack, gdi32, \
-                                          urlmon, ole32, comctl32
+                                          urlmon, ole32, comctl32, msimg32
 
 API_HANDLERS = (
                     # Kernel mode
@@ -37,6 +37,7 @@ API_HANDLERS = (
                     ('urlmon', urlmon.Urlmon),
                     ('ole32', ole32.Ole32),
                     ('comctl32', comctl32.Comctl32),
+                    ('msimg32', msimg32.Msimg32),
                )
 
 

--- a/speakeasy/winenv/defs/windows/windef.py
+++ b/speakeasy/winenv/defs/windows/windef.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2020 FireEye, Inc. All Rights Reserved.
+
+from speakeasy.struct import EmuStruct, Ptr
+import ctypes as ct
+
+class POINT(EmuStruct):
+    def __init__(self, ptr_size):
+        super().__init__(ptr_size)
+        self.x = ct.c_uint32
+        self.y = ct.c_uint32
+
+
+class RECT(EmuStruct):
+    def __init__(self, ptr_size):
+        super().__init__(ptr_size)
+        self.left = ct.c_int32
+        self.top = ct.c_int32
+        self.right = ct.c_int32
+        self.bottom = ct.c_int32
+
+class MONITORINFO(EmuStruct):
+    def __init__(self, ptr_size):
+        super().__init__(ptr_size)
+        self.cbSize = ct.c_uint32
+        self.rcMonitor  = RECT
+        self.rcWORK  = RECT
+        self.dwFlags = ct.c_uint32
+


### PR DESCRIPTION
First stab at API hammering mitigation. Count the number of times a given API is called (paired with its return address). If above the given threshold, assume this is useless anti-sandbox AP hammering & attempt to patch the emulated bytes to prevent the API call and requiring Speakeasy to deal with it. Very incomplete, and currently based on a few examples seen some mass malware for 32-bit x86. 

Two types of calls are supported: call dword ptr [import_addr] and call <reg> are attempted to be dealt with. The first is easy, as there are enough bytes to patch in stack fixup code. The second changes the <reg> contents to point to allocated space with stack cleanup code, under the assumption (not always correct) that if we're in a tight loop with the register initialized prior to the loop with a useless API address, we can ignore a great number of calls this way and get farther in the emulation in the time allowed. Disassembly examination should probably be rethought a bit to better identify the types of calls being detected.

Configs & schema definition updated - in all current configs this feature is not enabled by default to allow bake-in time and to expand the implementation.