### PR TITLE
Adding API hammering allow_list

### DIFF
--- a/speakeasy/config_schema.json
+++ b/speakeasy/config_schema.json
@@ -222,6 +222,13 @@
                 "threshold": {
                     "type": "number",
                     "description": "Threshold for an individual API call to trigger API hammer mitigation"
+                },
+                "allow_list": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "List of allowed APIs (of the form '<dll_name>.<function_name>') to always allow despite API hammering mitigation being used"
                 }
             },
             "additionalProperties": false,


### PR DESCRIPTION
We want some API functions to be allowed despite triggering API hammering detection logic. Placeholder and start of list, with optional for list to be pulled from config.