### PR TITLE
Update msvcrt.py with calloc

### DIFF
--- a/speakeasy/winenv/api/usermode/msvcrt.py
+++ b/speakeasy/winenv/api/usermode/msvcrt.py
@@ -812,6 +812,23 @@ class Msvcrt(api.ApiHandler):
         chunk = self.heap_alloc(size, heap='HeapAlloc')
         return chunk
 
+    @apihook('calloc', argc=2, conv=e_arch.CALL_CONV_CDECL)
+    def calloc(self, emu, argv, ctx={}):
+        """
+        void *calloc(
+        size_t num,
+        size_t size
+        );
+        """
+        num,size, = argv
+
+        chunk = self.heap_alloc(num*size, heap='HeapAlloc')
+        
+        buf = b'\x00' * (num*size)
+        self.mem_write(chunk, buf)
+        
+        return chunk    
+    
     @apihook('free', argc=1, conv=e_arch.CALL_CONV_CDECL)
     def free(self, emu, argv, ctx={}):
         """


### PR DESCRIPTION
Update MSVCRT to support `calloc`

Documentation is for the call is https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/calloc?view=msvc-160

To be as accurate as possible, I initialized the memory with `0x00` per calloc's documentation. 