### PR TITLE
MultiByteToWideChar update

### DIFF
--- a/speakeasy/winenv/api/usermode/kernel32.py
+++ b/speakeasy/winenv/api/usermode/kernel32.py
@@ -2318,6 +2318,9 @@ class Kernel32(api.ApiHandler):
         (CodePage, dwFlags, lpMultiByteStr, cbMultiByte,
          lpWideCharStr, cchWideChar) = argv
 
+        cchWideChar = cchWideChar & 0xFFFFFFFF
+        cbMultiByte = cbMultiByte & 0xFFFFFFFF
+        
         rv = 0
         if cchWideChar == 0:
             if cbMultiByte == 0xFFFFFFFF:


### PR DESCRIPTION
Encountered an issue with a 64-bit `cchWideChar` value when emulating MD5 `df00d1192451268c31c1f8568d1ff472`.