### PR TITLE
Added a new "functions always exist" mode

### DIFF
--- a/speakeasy/config_schema.json
+++ b/speakeasy/config_schema.json
@@ -454,6 +454,10 @@
                     "type": "boolean",
                     "description": "When a sample attempts to load a module, always present a decoy module"
                 },
+                "functions_always_exist": {
+                    "type": "boolean",
+                    "description": "When a sample attempts to call a non-implemented API, always present a fake return value"
+                },
                 "user_modules": {
                     "type": "array",
                     "items": {

--- a/speakeasy/configs/default.json
+++ b/speakeasy/configs/default.json
@@ -256,6 +256,8 @@
 
     "modules": {
         "modules_always_exist": false,
+        "functions_always_exist": false,
+
         "module_directory_x86": "$ROOT$/winenv/decoys/x86",
         "module_directory_x64": "$ROOT$/winenv/decoys/amd64",
 

--- a/speakeasy/configs/win10_basic_analysis.json
+++ b/speakeasy/configs/win10_basic_analysis.json
@@ -182,6 +182,8 @@
 
     "modules": {
         "modules_always_exist": false,
+        "functions_always_exist": false,
+
         "module_directory_x86": "$ROOT$/winenv/decoys/x86",
         "module_directory_x64": "$ROOT$/winenv/decoys/amd64",
 

--- a/speakeasy/configs/win10_full_analysis.json
+++ b/speakeasy/configs/win10_full_analysis.json
@@ -202,6 +202,8 @@
 
     "modules": {
         "modules_always_exist": false,
+        "functions_always_exist": false,
+
         "module_directory_x86": "$ROOT$/winenv/decoys/x86",
         "module_directory_x64": "$ROOT$/winenv/decoys/amd64",
 

--- a/speakeasy/configs/win7_full_analysis.json
+++ b/speakeasy/configs/win7_full_analysis.json
@@ -203,6 +203,8 @@
 
     "modules": {
         "modules_always_exist": false,
+        "functions_always_exist": false,
+
         "module_directory_x86": "$ROOT$/winenv/decoys/x86",
         "module_directory_x64": "$ROOT$/winenv/decoys/amd64",
 

--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -132,6 +132,7 @@ class WindowsEmulator(BinaryEmulator):
         self.do_strings = self.config_analysis.get('strings', False)
         self.registry_config = self.config.get('registry', {})
         self.modules_always_exist = self.config_modules.get('modules_always_exist', False)
+        self.functions_always_exist = self.config_modules.get('functions_always_exist', False)
 
     def get_registry_config(self):
         """
@@ -1144,6 +1145,16 @@ class WindowsEmulator(BinaryEmulator):
                 ret = self.get_ret_address()
                 self.log_api(ret, imp_api, rv, argv)
                 self.do_call_return(hook.argc, ret, rv, conv=hook.call_conv)
+                return
+            elif self.functions_always_exist:
+                imp_api = '%s.%s' % (dll, name)
+                conv = _arch.CALL_CONV_STDCALL
+                argc = 4
+                argv = self.get_func_argv(conv, argc)
+                rv = 1
+                ret = self.get_ret_address()
+                self.log_api(ret, imp_api, rv, argv)
+                self.do_call_return(argc, ret, rv, conv=conv)
                 return
 
             run = self.get_current_run()


### PR DESCRIPTION
This is a new option called "functions_always_exist", similar to "modules_always_exist", but for function.

It pretends that every function exists that the target sample tries to call, and returns a fake value. This is great for quick debugging, or when trying to determine all the missing API hooks. 

Currently this always returns a fixed constant 1 (one) as the return value from the faked function.