### PR TITLE
Make impname an optional parameter, and default to the function name …

### DIFF
--- a/speakeasy/winenv/api/api.py
+++ b/speakeasy/winenv/api/api.py
@@ -17,12 +17,12 @@ class ApiHandler(object):
     name = ''
 
     @staticmethod
-    def apihook(impname, argc=0, conv=_arch.CALL_CONV_STDCALL, ordinal=None):
+    def apihook(impname=None, argc=0, conv=_arch.CALL_CONV_STDCALL, ordinal=None):
 
         def apitemp(f):
             if not callable(f):
                 raise ApiEmuError('Invalid function type supplied: %s' % (str(f)))
-            f.__apihook__ = (impname, f, argc, conv, ordinal)
+            f.__apihook__ = (impname or f.__name__, f, argc, conv, ordinal)
             return f
 
         return apitemp


### PR DESCRIPTION
…in this case.

This allows writing new API handlers with less redundant boilerplate code. E.g.
```
@apihook(argc=2)
def SomeApiName(self, emu, argv, ctx={}):
```

Instead of:
```
@apihook('SomeApiName', argc=2)
def SomeApiName(self, emu, argv, ctx={}):
```
