### PR TITLE
Bugfixes

### DIFF
--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -474,7 +474,10 @@ class WindowsEmulator(BinaryEmulator):
         """
         Terminate a process (i.e. remove it from the known process list)
         """
-        self.processes.remove(proc)
+        try:
+            self.processes.remove(proc)
+        except ValueError:
+            pass
 
     def get_current_thread(self):
         """
@@ -1679,7 +1682,7 @@ class WindowsEmulator(BinaryEmulator):
         if isinstance(base, str):
             base = int(base, 16)
 
-        mod.decoy_path = modconf.get('path', emu_path)
+        mod.decoy_path = modconf.get('path', emu_path) or (name + '.dll')
         # Reserve memory for the module
         res, size = self.get_valid_ranges(mod.image_size,
                                           base)


### PR DESCRIPTION
This PR fixes 2 small bugs in `winemu.py`:

- Don't raise an exception when a target sample tries to terminate a non-existing process (i.e. could have been terminated in the meanwhile due to some other reason)
- Fix missing module DLL names in the output when "modules_always_exist" is set to True

Before (missing DLL name):
```
(...)
0x140009276: 'kernel32.MultiByteToWideChar(0x0, 0x0, "root\\SecurityCenter2", 0xffffffff, 0x1211468, 0x400)' -> 0x2a
0xfeee0040: module_entry: Caught error: unsupported_api
Invalid memory read (UC_ERR_READ_UNMAPPED)
Unsupported API: .SysAllocString (ret: 0x140009284)
* Finished emulating
(... emulation stops ...)
```

After:
```
(...)
0x140009276: 'kernel32.MultiByteToWideChar(0x0, 0x0, "root\\SecurityCenter2", 0xffffffff, 0x1211468, 0x400)' -> 0x2a
0x140009284: 'OleAut32.SysAllocString("root\\SecurityCenter2")' -> 0x7954
(... emulation keeps going ...)
```