### PR TITLE
Export table API Ordering

### DIFF
--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -1653,6 +1653,7 @@ class WindowsEmulator(BinaryEmulator):
             func_names = new
 
             func_names = [fn for o, fn in func_names]
+            func_names.sort()
 
             exports = []
             ords = [o for o, fn in funcs if o is not None]


### PR DESCRIPTION
Currently the APIs in the export table are ordered alphabetically from all of the hooks specified. The code then appends an 'A' and 'W' variant of each hooked export. The problem is the alphabetic order is not preserved.

For example for user32.dll if you look at the export table you will see:

```
.
.
.
LookupIconIdFromDirectory
MessageBox
MessageBoxEx
MsgWaitForMultipleObjects
.
.
.
LookupIconIdFromDirectoryA
LookupIconIdFromDirectoryA
MessageBoxA
MessageBoxW
MessageBoxExA
MessageBoxExW
MsgWaitForMultipleObjectsA
MsgWaitForMultipleObjectsW
.
.
.
```

As you can see the names are not in order in several ways. This pull request performs a sort of the function names after the addition of the 'A' and 'W' is made.

This came up when looking at malware which was manually parsing the export table and stopped once it got to a name which was greater than what is was looking for, since it was assuming that the exported names would be in order.