### PR TITLE
Fix recursive paths in MANIFEST.in for installing with setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 global-exclude *.pyc
 
-recursive-include speakeasy/winenv/decoys/ *
-recursive-include speakeasy/resources/ *
+recursive-include speakeasy/winenv/decoys *
+recursive-include speakeasy/resources *
 include speakeasy/configs/*.json
 include speakeasy/config_schema.json


### PR DESCRIPTION
This fixes #122 so that the library can be properly installed on Windows by running `python setup.py install`.