### PR TITLE
Updated required unicorn version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
         'pefile',
         'capstone',
         'lznt1',
-        'unicorn==1.0.2rc4',
+        'unicorn==1.0.2',
         'jsonschema'
     ],
     classifiers=[


### PR DESCRIPTION
Quick change to make sure that the unicorn version requirement in `setup.py` is updated from `1.0.2rc4` to `1.0.2`.

Related to this issue: https://github.com/fireeye/speakeasy/issues/130

This pull request should also fix this issue on Remnux: https://github.com/REMnux/salt-states/issues/172
