### PR TITLE
Adding list_subkeys and create_key log 

### DIFF
--- a/speakeasy/winenv/api/usermode/advapi32.py
+++ b/speakeasy/winenv/api/usermode/advapi32.py
@@ -273,7 +273,7 @@ class AdvApi32(api.ApiHandler):
                             name = name.encode('utf-8')
                         self.mem_write(lpName, name)
                         rv = windefs.ERROR_SUCCESS
-
+            self.log_registry_access(key.get_path(), "list_subkeys")
         return rv
 
     @apihook('RegCreateKey', argc=3)
@@ -297,7 +297,9 @@ class AdvApi32(api.ApiHandler):
                 if lpSubKey:
                     lpSubKey = self.read_mem_string(lpSubKey, cw)
                     argv[1] = lpSubKey
-                    self.emu.reg_create_key(key.get_path() + '\\' + lpSubKey)
+                    sub_key_path = key.get_path() + '\\' + lpSubKey
+                    self.emu.reg_create_key(sub_key_path)
+                    self.log_registry_access(sub_key_path, "create_key")
                 else:
                     hkey = (hkey).to_bytes(self.get_ptr_size(), 'little')
                     self.mem_write(phkResult, hkey)

--- a/speakeasy/winenv/api/usermode/wininet.py
+++ b/speakeasy/winenv/api/usermode/wininet.py
@@ -404,6 +404,7 @@ class Wininet(api.ApiHandler):
             port = 80
         else:
             port = 443
+        self.log_http(crack.netloc, port, headers=lpszHeaders)
         sess = wini.new_session(crack.netloc, port, '', '', '', defs, dwContext)
         if not sess:
             return 0


### PR DESCRIPTION
Hey there!
I found out that there were not logs in the registry report if the sample tries to create a new key or tries to enumerate the registries subkeys.
I have no idea if these logs were missing because were considered not important, if this was the case, feel free to close the pr. 