### PR TITLE
Bug fix in log_file_access

### DIFF
--- a/speakeasy/profiler.py
+++ b/speakeasy/profiler.py
@@ -197,7 +197,8 @@ class Profiler(object):
             if event_type == et:
                 for fa in run.file_access:
                     if path == fa.get('path') and fa['event'] == et:
-                        fa['size'] += size
+                        if size:
+                            fa['size'] += size
                         return
 
         enc = None


### PR DESCRIPTION
In many cases, like if a file is copied, `log_file_access` is called without size, which makes it crash:
```
0x100014cc: Error while calling API handler for KERNEL32.CopyFileW:
Traceback (most recent call last):
  File "speakeasy/speakeasy/windows/winemu.py", line 1126, in handle_import_func
    rv = self.api.call_api_func(mod, func, argv, ctx=default_ctx)
  File "speakeasy/speakeasy/winenv/api/winapi.py", line 77, in call_api_func
    return func(mod, self.emu, argv, ctx)
  File "speakeasy/speakeasy/winenv/api/usermode/kernel32.py", line 3258, in CopyFile
    self.log_file_access(_dst, 'write')
  File "speakeasy/speakeasy/winenv/api/api.py", line 215, in log_file_access
    profiler.log_file_access(run, path, event_type, data, handle,
  File "speakeasy/speakeasy/profiler.py", line 200, in log_file_access
    fa['size'] += size
KeyError: 'size'
```
Because of this
```
        for et in ('write', 'read'):
            if event_type == et:
                for fa in run.file_access:
                    if path == fa.get('path') and fa['event'] == et:
                        fa['size'] += size
                        return
```
So here is a simple fix for it.