### PR TITLE
Fix CreateFile emulation

### DIFF
--- a/speakeasy/winenv/api/usermode/kernel32.py
+++ b/speakeasy/winenv/api/usermode/kernel32.py
@@ -3286,6 +3286,8 @@ class Kernel32(api.ApiHandler):
         if ad:
             argv[1] = ' | '.join(ad)
 
+        disp_bytes = disp.to_bytes(8, 'little')
+        disp = int(int.from_bytes(disp_bytes[0:4], 'little')
         cd = windefs.get_create_disposition(disp)
         if cd:
             argv[4] = cd

--- a/speakeasy/winenv/api/usermode/kernel32.py
+++ b/speakeasy/winenv/api/usermode/kernel32.py
@@ -3287,7 +3287,7 @@ class Kernel32(api.ApiHandler):
             argv[1] = ' | '.join(ad)
 
         disp_bytes = disp.to_bytes(8, 'little')
-        disp = int(int.from_bytes(disp_bytes[0:4], 'little')
+        disp = int(int.from_bytes(disp_bytes[0:4], 'little'))
         cd = windefs.get_create_disposition(disp)
         if cd:
             argv[4] = cd


### PR DESCRIPTION
The real CreateFile API only reads a DWORD of the disposition value. Therefore it is completely valid for malicious programs/shellcode to pass a QWORD (in x64) with invalid leading bytes and have the system API work (e.g. 0xcccccccc00000003 = OPEN_EXISTING). Without this change, Speakeasy fails to return a handle because it can't match the disposition parameter with any of the windef disposition values.