### PR TITLE
Fix bug in emulated argument parsing

### DIFF
--- a/speakeasy/windows/win32.py
+++ b/speakeasy/windows/win32.py
@@ -145,7 +145,7 @@ class Win32Emulator(WindowsEmulator):
             self.disasm_eng = cs.Cs(cs.CS_ARCH_X86, disasm_mode)
 
         if not data:
-            file_name = os.path.basename(path) + '.exe'
+            file_name = os.path.basename(path)
             mod_name = os.path.splitext(file_name)[0]
 
         else:


### PR DESCRIPTION
This addition of adding the ".exe" extension causes improper emulated API results when the emulated program attempts to parse its command line options. The function https://github.com/fireeye/speakeasy/blob/bf876c72c362e31193b9d3493d31a78ecbf674ef/speakeasy/windows/win32.py#L125
data parameter is optional, and so many of the examples (including run_speakeasy.py) do not set/use it when calling `load_module` This means the '.exe' will be appended to the file_name and that if an emulated process, accesses argv[0] the output will be: `C:\Windows\System32\Malware.exe.exe` (default config file) When argv[0] should return `C:\Windows\System32\Malware.exe`
