### PR TITLE
Bug fixes, CryptDecrypt, CryptDeriveKey, SetWindowLong

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ capstone
 lznt1
 unicorn==1.0.2
 jsonschema
+pycryptodome

--- a/speakeasy/binemu.py
+++ b/speakeasy/binemu.py
@@ -686,7 +686,7 @@ class BinaryEmulator(MemoryManager):
         i = 0
 
         if width == 1:
-            decode = 'utf-8'
+            decode = 'latin1'
         elif width == 2:
             decode = 'utf-16le'
         else:

--- a/speakeasy/winenv/api/usermode/user32.py
+++ b/speakeasy/winenv/api/usermode/user32.py
@@ -795,6 +795,19 @@ class User32(api.ApiHandler):
 
         return rv
 
+    @apihook('SetWindowLong', argc=3)
+    def SetWindowLong(self, emu, argv, ctx={}):
+        """
+        LONG SetWindowLongA(
+          HWND hWnd,
+          int  nIndex,
+          LONG dwNewLong
+        );
+        """
+
+
+        return 1
+
     @apihook('DialogBoxParam', argc=5)
     def DialogBoxParam(self, emu, argv, ctx={}):
         '''

--- a/speakeasy/winenv/defs/windows/advapi32.py
+++ b/speakeasy/winenv/defs/windows/advapi32.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2020 FireEye, Inc. All Rights Reserved.
 
 from speakeasy.struct import EmuStruct, Ptr
+import ctypes as ct
 
 NTE_BAD_ALGID = 0x80090008
 
@@ -14,6 +15,13 @@ class SERVICE_TABLE_ENTRY(EmuStruct):
         super().__init__(ptr_size)
         self.lpServiceName = Ptr
         self.lpServiceProc = Ptr
+
+class HCRYPTKEY(EmuStruct):
+    def __init__(self, ptr_size):
+        super().__init__(ptr_size)
+        self.Algid = ct.c_uint32
+        self.keylen = ct.c_uint32
+        self.keyp = Ptr
 
 
 def get_define_int(define, prefix=''):


### PR DESCRIPTION
### Bug fixes
- speakeasy/binemu.py: `read_mem_string`: encoding changed to latin1
instead of utf-8
- speakeasy/windows/winemu.py: `map_pe`: use `pe.image_size` instead of
`len(pe.mapped_image)`, which correctly reflects the size of the virtual
address space of the emulated process
- speakeasy/windows/winemu.py: `_dispatch_seh_x86`: unconditionally
clobber `ebx`, because the Windows kernel clobbers it
- speakeasy/windows/winemu.py: `_continue_seh_x86`: unconditionally
restore thread context so registers continue to reflect what they were before the
exception happened

I also added API hooks for `CryptDecrypt`, `CryptDeriveKey`, and
`SetWindowLong` (which is just a stub). `CryptDecrypt` and `CryptDeriveKey`
only support RC4. With the inclusion of RC4 stuff, `pycryptodome` is now
a dependency.