### PR TITLE
Bug fixes, implicit TLS support

### DIFF
--- a/speakeasy/binemu.py
+++ b/speakeasy/binemu.py
@@ -1098,3 +1098,20 @@ class BinaryEmulator(MemoryManager):
             hook.add()
 
         return hook
+
+    def add_invalid_instruction_hook(self, cb, ctx=[], emu=None):
+        if not emu:
+            emu = self
+
+        hook = common.InvalidInstructionHook(emu, self.emu_eng, cb, ctx=[])
+        hl = self.hooks.get(common.HOOK_INSN)
+
+        if not hl:
+            self.hooks.update({common.HOOK_INSN_INVALID: [hook, ]})
+        else:
+            hl.insert(0, hook)
+
+        if self.emu_eng:
+            hook.add()
+
+        return hook

--- a/speakeasy/binemu.py
+++ b/speakeasy/binemu.py
@@ -1104,7 +1104,7 @@ class BinaryEmulator(MemoryManager):
             emu = self
 
         hook = common.InvalidInstructionHook(emu, self.emu_eng, cb, ctx=[])
-        hl = self.hooks.get(common.HOOK_INSN)
+        hl = self.hooks.get(common.HOOK_INSN_INVALID)
 
         if not hl:
             self.hooks.update({common.HOOK_INSN_INVALID: [hook, ]})

--- a/speakeasy/engines/unicorn_eng.py
+++ b/speakeasy/engines/unicorn_eng.py
@@ -132,7 +132,8 @@ class EmuEngine(object):
                         common.HOOK_MEM_READ: uc.UC_HOOK_MEM_READ,
                         common.HOOK_MEM_WRITE: uc.UC_HOOK_MEM_WRITE,
                         common.HOOK_INTERRUPT: uc.UC_HOOK_INTR,
-                        common.HOOK_INSN: uc.UC_HOOK_INSN
+                        common.HOOK_INSN: uc.UC_HOOK_INSN,
+                        common.HOOK_INSN_INVALID: uc.UC_HOOK_INSN_INVALID
         }
 
     def _sec_to_usec(self, sec):

--- a/speakeasy/speakeasy.py
+++ b/speakeasy/speakeasy.py
@@ -45,6 +45,7 @@ class Speakeasy(object):
         self.api_hooks = []
         self.code_hooks = []
         self.dyn_code_hooks = []
+        self.invalid_insn_hooks = []
         self.mem_read_hooks = []
         self.argv = argv
         self.exit_event = exit_event
@@ -132,6 +133,10 @@ class Speakeasy(object):
             h = self.dyn_code_hooks.pop(0)
             cb, ctx = h
             self.add_dyn_code_hook(cb, ctx)
+        while self.invalid_insn_hooks:
+            h = self.invalid_insn_hooks.pop(0)
+            cb, ctx = h
+            self.add_invalid_instruction_hook(cb, ctx)
         while self.mem_read_hooks:
             h = self.mem_read_hooks.pop(0)
             cb, begin, end = h
@@ -429,6 +434,21 @@ class Speakeasy(object):
             self.mem_write_hooks.append((cb, begin, end))
             return
         return self.emu.add_instruction_hook(cb, begin=begin, end=end, emu=self, insn=700)
+
+    def add_invalid_instruction_hook(self, cb: Callable, ctx=[]):
+        """
+        Set a callback to fire when an invalid instruction is attempted
+        to be executed
+
+        args:
+            cb: Callable python function to execute
+        return:
+            Hook object for newly registered hooks
+        """
+        if not self.emu:
+            self.invalid_insn_hooks.append((cb, ctx))
+            return
+        return self.emu.add_invalid_instruction_hook(cb, ctx)
 
     def add_mem_invalid_hook(self, cb: Callable):
         """

--- a/speakeasy/speakeasy.py
+++ b/speakeasy/speakeasy.py
@@ -44,6 +44,7 @@ class Speakeasy(object):
         self.emu = None
         self.api_hooks = []
         self.code_hooks = []
+        self.dyn_code_hooks = []
         self.mem_read_hooks = []
         self.argv = argv
         self.exit_event = exit_event
@@ -127,6 +128,10 @@ class Speakeasy(object):
             h = self.code_hooks.pop(0)
             cb, begin, end, ctx = h
             self.add_code_hook(cb, begin, end, ctx)
+        while self.dyn_code_hooks:
+            h = self.dyn_code_hooks.pop(0)
+            cb, ctx = h
+            self.add_dyn_code_hook(cb, ctx)
         while self.mem_read_hooks:
             h = self.mem_read_hooks.pop(0)
             cb, begin, end = h
@@ -345,6 +350,21 @@ class Speakeasy(object):
             self.code_hooks.append((cb, begin, end, ctx))
             return
         return self.emu.add_code_hook(cb, begin=begin, end=end, ctx=ctx, emu=self)
+
+    def add_dyn_code_hook(self, cb: Callable, ctx={}):
+        """
+        Set a callback to fire when dynamically generated/copied code is executed
+
+        args:
+            cb: Callable python function to execute
+            ctx: Optional context to pass back and forth between the hook function
+        return:
+            Hook object for newly registered hooks
+        """
+        if not self.emu:
+            self.dyn_code_hooks.append((cb, ctx))
+            return
+        return self.emu.add_dyn_code_hook(cb, ctx=ctx, emu=self)
 
     def add_mem_read_hook(self, cb: Callable, begin=1, end=0):
         """

--- a/speakeasy/windows/fileman.py
+++ b/speakeasy/windows/fileman.py
@@ -190,21 +190,25 @@ class FileManager(object):
     """
     Manages file system activity during emulation
     """
-    def __init__(self, config=None, modules=None, cmdline=None, emu=None):
+    def __init__(self, config, emu):
         super(FileManager, self).__init__()
         self.file_handles = {}
         self.pipe_handles = {}
         self.file_maps = {}
+
+        # top level config
         self.config = config
-        # self.all_modules is the modules key from the config JSON file
-        self.all_modules = modules
 
-        # This allows us to serve the emulated module for when the full
-        # path to it is not given
-        if cmdline is not None:
-            self.emulated_binname = shlex.split(cmdline)[0]
-
+        # "files" key of config
+        self.file_config = self.config.get('filesystem', {})
         self.emu = emu
+
+        cmdline = self.config.get('command_line')
+
+        if cmdline is None:
+            cmdline = ""
+
+        self.emulated_binname = shlex.split(cmdline)[0]
 
         # First file in this list seems to always be the module itself
         self.files = []
@@ -223,7 +227,7 @@ class FileManager(object):
             return hnd
 
     def walk_files(self):
-        for f in self.config.get('files', []):
+        for f in self.file_config.get('files', []):
             path = f.get('emu_path')
             if not path:
                 continue
@@ -306,34 +310,36 @@ class FileManager(object):
     def get_emu_file(self, path):
         # Does this file exist in our emulation environment
         # See if we have a handler for this exact file
-        for f in self.config.get('files', []):
+        for f in self.file_config.get('files', []):
             mode = f.get('mode')
             if mode == 'full_path':
                 if fnmatch.fnmatch(path.lower(), f.get('emu_path').lower()):
                     return f
 
+        all_modules = self.config.get('modules')
+
         if self.emu.arch == _arch.ARCH_X86:
-            decoy_dir = self.all_modules.get('module_directory_x86', [])
+            decoy_dir = all_modules.get('module_directory_x86', [])
         else:
-            decoy_dir = self.all_modules.get('module_directory_x64', [])
+            decoy_dir = all_modules.get('module_directory_x64', [])
 
         ext = os.path.splitext(path)[1]
 
         # Check if we can load the contents of a decoy DLL
-        for f in self.all_modules.get('user_modules', []):
+        for f in all_modules.get('user_modules', []):
             if f.get('path') == path:
                 newconf = dict()
                 newconf['path'] = os.path.join(decoy_dir, f.get('name') + ext)
                 return newconf
 
-        for f in self.all_modules.get('system_modules', []):
+        for f in all_modules.get('system_modules', []):
             if f.get('path') == path:
                 newconf = dict()
                 newconf['path'] = os.path.join(decoy_dir, f.get('name') + ext)
                 return newconf
 
         # If no full path handler exists, do we have an extension handler?
-        for f in self.config.get('files', []):
+        for f in self.file_config.get('files', []):
             path_ext = ntpath.splitext(path)[-1:][0].strip('.')
             if path_ext:
                 mode = f.get('mode')
@@ -342,7 +348,7 @@ class FileManager(object):
                         return f
 
         # Finally, do we have a catch-all default handler?
-        for f in self.config.get('files', []):
+        for f in self.file_config.get('files', []):
 
             mode = f.get('mode')
             if mode == 'default':

--- a/speakeasy/windows/fileman.py
+++ b/speakeasy/windows/fileman.py
@@ -201,7 +201,8 @@ class FileManager(object):
 
         # This allows us to serve the emulated module for when the full
         # path to it is not given
-        self.emulated_binname = shlex.split(cmdline)[0]
+        if cmdline is not None:
+            self.emulated_binname = shlex.split(cmdline)[0]
 
         self.emu = emu
 

--- a/speakeasy/windows/fileman.py
+++ b/speakeasy/windows/fileman.py
@@ -5,6 +5,7 @@ import io
 import ntpath
 import hashlib
 import fnmatch
+import shlex
 import speakeasy.winenv.defs.windows.windows as windefs
 import speakeasy.winenv.arch as _arch
 from speakeasy.errors import FileSystemEmuError
@@ -200,12 +201,11 @@ class FileManager(object):
 
         # This allows us to serve the emulated module for when the full
         # path to it is not given
-        binname = cmdline.partition(" ")[0]
-
-        self.emulated_binname = binname
+        self.emulated_binname = shlex.split(cmdline)[0]
 
         self.emu = emu
 
+        # First file in this list seems to always be the module itself
         self.files = []
 
     def file_create_mapping(self, hfile, name, size, prot):
@@ -316,24 +316,19 @@ class FileManager(object):
         else:
             decoy_dir = self.all_modules.get('module_directory_x64', [])
 
-        dot = path.rfind(".")
-        
-        if dot != -1:
-            ext = path[dot:]
-        else:
-            ext = ""
+        ext = os.path.splitext(path)[1]
 
         # Check if we can load the contents of a decoy DLL
         for f in self.all_modules.get('user_modules', []):
             if f.get('path') == path:
                 newconf = dict()
-                newconf['path'] = decoy_dir + "/" + f.get('name') + ext
+                newconf['path'] = os.path.join(decoy_dir, f.get('name') + ext)
                 return newconf
 
         for f in self.all_modules.get('system_modules', []):
             if f.get('path') == path:
                 newconf = dict()
-                newconf['path'] = decoy_dir + "/" + f.get('name') + ext
+                newconf['path'] = os.path.join(decoy_dir, f.get('name') + ext)
                 return newconf
 
         # If no full path handler exists, do we have an extension handler?

--- a/speakeasy/windows/fileman.py
+++ b/speakeasy/windows/fileman.py
@@ -200,12 +200,7 @@ class FileManager(object):
 
         # This allows us to serve the emulated module for when the full
         # path to it is not given
-        space = cmdline.find(" ")
-
-        if space != -1:
-            binname = cmdline[:space]
-        else:
-            binname = cmdline
+        binname = cmdline.partition(" ")[0]
 
         self.emulated_binname = binname
 

--- a/speakeasy/windows/objman.py
+++ b/speakeasy/windows/objman.py
@@ -487,6 +487,17 @@ class Thread(KernelObject):
     def get_token(self):
         return self.token
 
+    def init_tls(self, tls_dir, modname):
+        ptrsz = self.emu.get_ptr_size()
+
+        tls_dirp = self.emu.mem_map(ptrsz, tag='emu.tls.%s' % (modname))
+
+        self.emu.mem_write(tls_dirp, tls_dir)
+
+        self.teb.object.ThreadLocalStoragePointer = tls_dirp
+        self.teb.write_back()
+
+        return
 
 class Token(KernelObject):
     """

--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -98,8 +98,7 @@ class WindowsEmulator(BinaryEmulator):
         self.wintypes = windef
         # OS resource managers
         self.regman = RegistryManager(self.get_registry_config())
-        self.fileman = FileManager(self.get_filesystem_config(),
-                self.config_modules, self.command_line, self)
+        self.fileman = FileManager(config, self)
         self.netman = NetworkManager(config=self.get_network_config())
         self.driveman = DriveManager(config=self.get_drive_config())
         self.cryptman = CryptoManager()

--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -98,7 +98,8 @@ class WindowsEmulator(BinaryEmulator):
         self.wintypes = windef
         # OS resource managers
         self.regman = RegistryManager(self.get_registry_config())
-        self.fileman = FileManager(self.get_filesystem_config())
+        self.fileman = FileManager(self.get_filesystem_config(),
+                self.config_modules, self.command_line, self)
         self.netman = NetworkManager(config=self.get_network_config())
         self.driveman = DriveManager(config=self.get_drive_config())
         self.cryptman = CryptoManager()
@@ -368,6 +369,7 @@ class WindowsEmulator(BinaryEmulator):
             thread = self.get_current_thread()
             if thread:
                 self.init_teb(thread, self.curr_process.get_peb())
+                self.init_tls(thread)
 
         self.set_pc(run.start_addr)
         return run
@@ -633,6 +635,30 @@ class WindowsEmulator(BinaryEmulator):
             thread.init_teb(self.fs_addr, peb.address)
         elif self.get_arch() == _arch.ARCH_AMD64:
             thread.init_teb(self.gs_addr, peb.address)
+
+    def init_tls(self, thread):
+        """
+        Initialize implicit thread local storage. Meant to be
+        called after init_teb.
+        """
+        ptrsz = self.get_ptr_size()
+        run = self.curr_run
+        module = self.get_mod_from_addr(run.start_addr)
+
+        if module:
+            modname = module.emu_path
+            modname = modname[modname.find("\\")+2:]
+
+            # Get the virtual address of the TLS directory, which will always
+            # be 9 in the data directory
+            tls_dirp = module.OPTIONAL_HEADER.DATA_DIRECTORY[9].VirtualAddress
+            tls_dirp += module.OPTIONAL_HEADER.ImageBase
+
+            tls_dir = self.mem_read(tls_dirp, ptrsz)
+
+            thread.init_tls(tls_dir, modname[:modname.find(".")])
+
+        return
 
     def load_pe(self, path=None, data=None, imp_id=winemu.IMPORT_HOOK_ADDR):
         """

--- a/speakeasy/windows/winemu.py
+++ b/speakeasy/windows/winemu.py
@@ -647,7 +647,8 @@ class WindowsEmulator(BinaryEmulator):
 
         if module:
             modname = module.emu_path
-            modname = modname[modname.find("\\")+2:]
+            tokens = modname.split("\\")
+            modname = tokens[len(tokens) - 1]
 
             # Get the virtual address of the TLS directory, which will always
             # be 9 in the data directory
@@ -656,7 +657,7 @@ class WindowsEmulator(BinaryEmulator):
 
             tls_dir = self.mem_read(tls_dirp, ptrsz)
 
-            thread.init_tls(tls_dir, modname[:modname.find(".")])
+            thread.init_tls(tls_dir, os.path.splitext(modname)[0])
 
         return
 

--- a/speakeasy/winenv/api/usermode/kernel32.py
+++ b/speakeasy/winenv/api/usermode/kernel32.py
@@ -1220,6 +1220,25 @@ class Kernel32(api.ApiHandler):
         obj.suspend_count += 1
         return rv
 
+    @apihook('GetThreadId', argc=1)
+    def GetThreadId(self, emu, argv, ctx={}):
+        """
+        DWORD GetThreadId(
+          HANDLE Thread
+        );
+        """
+        Thread, = argv
+
+        if not Thread:
+            return 0
+
+        obj = self.get_object_from_handle(Thread)
+
+        if not obj:
+            return 0
+
+        return obj.get_id()
+
     @apihook('VirtualQuery', argc=3)
     def VirtualQuery(self, emu, argv, ctx={}):
         '''
@@ -2071,10 +2090,9 @@ class Kernel32(api.ApiHandler):
         '''
         HANDLE GetCurrentThread();
         '''
-
-        rv = self.get_max_int()
-
-        return rv
+        thread = emu.get_current_thread()
+        obj = emu.om.get_object_from_addr(thread.address)
+        return emu.get_object_handle(obj)
 
     @apihook('TlsAlloc', argc=0)
     def TlsAlloc(self, emu, argv, ctx={}):
@@ -5388,6 +5406,15 @@ class Kernel32(api.ApiHandler):
 
         return rv
 
+    @apihook('WakeAllConditionVariable', argc=1)
+    def WakeAllConditionVariable(self, emu, argv, ctx={}):
+        '''
+        void WakeAllConditionVariable(
+          PCONDITION_VARIABLE ConditionVariable
+        );
+        '''
+        return
+
     @apihook('Wow64DisableWow64FsRedirection', argc=1)
     def Wow64DisableWow64FsRedirection(self, emu, argv, ctx={}):
         '''
@@ -5411,3 +5438,70 @@ class Kernel32(api.ApiHandler):
         rv = 1
 
         return rv
+
+    @apihook('EnumProcesses', argc=3)
+    def EnumProcesses(self, emu, argv, ctx={}):
+        '''
+        BOOL EnumProcesses(
+          DWORD   *lpidProcess,
+          DWORD   cb,
+          LPDWORD lpcbNeeded
+        );
+        '''
+        lpidProcess, cb, lpcbNeeded = argv
+        processes = emu.get_processes()
+
+        lpidProcess_cursor = lpidProcess
+        lim = min(cb / 4, len(processes))
+
+        for i in range(lim):
+            pid = processes[i].pid.to_bytes(4, "little")
+            self.mem_write(lpidProcess_cursor, pid)
+            lpidProcess_cursor += 4
+
+        pcbNeeded = lim
+        self.mem_write(lpcbNeeded, pcbNeeded.to_bytes(4, "little"))
+
+        return 1
+
+    @apihook('GetModuleFileNameExA', argc=4)
+    def GetModuleFileNameExA(self, emu, argv, ctx={}):
+        '''
+        DWORD GetModuleFileNameExA(
+          HANDLE  hProcess,
+          HMODULE hModule,
+          LPSTR   lpFilename,
+          DWORD   nSize
+        );
+        '''
+        hProcess, hModule, lpFilename, nSize = argv
+
+        if hModule:
+            return self.GetModuleFileName(hModule, lpFilename, nSize)
+
+        size = 0
+        cw = self.get_char_width(ctx)
+
+        proc = self.get_object_from_handle(hProcess)
+
+        if proc == None:
+            return 
+
+        filename = proc.get_process_path()
+
+        if filename:
+            if cw == 2:
+                out = filename.encode('utf-16le')
+            elif cw == 1:
+                out = filename.encode('utf-8')
+
+            size = int(len(out) / cw)
+            if nSize < size + 1 * cw:  # null terminator
+                emu.set_last_error(windefs.ERROR_INSUFFICIENT_BUFFER)
+                out = out[:nSize - 1 * cw] + b'\0' * cw
+            else:
+                out += b'\0' * cw
+
+            self.mem_write(lpFilename, out)
+
+        return size

--- a/speakeasy/winenv/api/usermode/kernel32.py
+++ b/speakeasy/winenv/api/usermode/kernel32.py
@@ -5452,7 +5452,7 @@ class Kernel32(api.ApiHandler):
         processes = emu.get_processes()
 
         lpidProcess_cursor = lpidProcess
-        lim = min(cb / 4, len(processes))
+        lim = min(cb // 4, len(processes))
 
         for i in range(lim):
             pid = processes[i].pid.to_bytes(4, "little")
@@ -5495,7 +5495,7 @@ class Kernel32(api.ApiHandler):
             elif cw == 1:
                 out = filename.encode('utf-8')
 
-            size = int(len(out) / cw)
+            size = len(out) // cw
             if nSize < size + 1 * cw:  # null terminator
                 emu.set_last_error(windefs.ERROR_INSUFFICIENT_BUFFER)
                 out = out[:nSize - 1 * cw] + b'\0' * cw

--- a/speakeasy/winenv/api/usermode/rpcrt4.py
+++ b/speakeasy/winenv/api/usermode/rpcrt4.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2020 FireEye, Inc. All Rights Reserved.
+
+import random
+
+import speakeasy.winenv.defs.windows.windows as windefs
+
+from .. import api
+
+class RPCRT4(api.ApiHandler):
+    """
+    Implements exported functions from rpcrt4.dll
+    """
+    name = 'rpcrt4'
+    apihook = api.ApiHandler.apihook
+    impdata = api.ApiHandler.impdata
+
+    def __init__(self, emu):
+        super(RPCRT4, self).__init__(emu)
+
+    @apihook('UuidCreate', argc=1)
+    def UuidCreate(self, emu, argv, ctx={}):
+        """
+        RPC_STATUS UuidCreate(
+          UUID *Uuid
+        );
+        """
+        uuidp, = argv
+
+        if not uuidp:
+            return 1
+
+        new_uuid = windefs.GUID()
+        new_uuid.Data1 = random.randint(0, 0xffffffff)
+        new_uuid.Data2 = random.randint(0, 0xffffffff) & 0xffff
+        new_uuid.Data3 = random.randint(0, 0xffffffff) & 0xffff
+        new_uuid.Data4 = random.randbytes(8)
+
+        self.mem_write(uuidp, new_uuid.get_bytes())
+
+        return 0
+    
+    @apihook('UuidToStringA', argc=2)
+    def UuidToStringA(self, emu, argv, ctx={}):
+        """
+        RPC_STATUS UuidToStringA(
+          const UUID *Uuid,
+          RPC_CSTR   *StringUuid
+        );
+        """
+        uuidp, stringp = argv
+
+        if not uuidp or not stringp:
+            return 1
+
+        uuid = self.mem_cast(windefs.GUID(), uuidp)
+
+        last = int.from_bytes(uuid.Data4, "little")
+
+        string = "%x-%x-%x-%x-%x" % (int(hex(uuid.Data1), 16),
+                int(hex(uuid.Data2), 16), int(hex(uuid.Data3), 16),
+                int(hex(last >> 48), 16),
+                int(hex(last & 0xffffffffffff), 16))
+
+        self.mem_write(stringp, bytes(string, "utf8"))
+
+        return 0

--- a/speakeasy/winenv/api/usermode/rpcrt4.py
+++ b/speakeasy/winenv/api/usermode/rpcrt4.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2020 FireEye, Inc. All Rights Reserved.
 
 import random
+import uuid
 
 import speakeasy.winenv.defs.windows.windows as windefs
 
@@ -52,15 +53,11 @@ class RPCRT4(api.ApiHandler):
         if not uuidp or not stringp:
             return 1
 
-        uuid = self.mem_cast(windefs.GUID(), uuidp)
+        uuid_bytes = self.mem_read(uuidp, windefs.GUID().sizeof())
+        uuid = uuid.UUID(bytes=uuid_bytes)
 
-        last = int.from_bytes(uuid.Data4, "little")
+        string = str(uuid)
 
-        string = "%x-%x-%x-%x-%x" % (int(hex(uuid.Data1), 16),
-                int(hex(uuid.Data2), 16), int(hex(uuid.Data3), 16),
-                int(hex(last >> 48), 16),
-                int(hex(last & 0xffffffffffff), 16))
-
-        self.mem_write(stringp, bytes(string, "utf8"))
+        self.mem_write(stringp, string.encode("utf-8"))
 
         return 0

--- a/speakeasy/winenv/api/usermode/rpcrt4.py
+++ b/speakeasy/winenv/api/usermode/rpcrt4.py
@@ -54,9 +54,9 @@ class RPCRT4(api.ApiHandler):
             return 1
 
         uuid_bytes = self.mem_read(uuidp, windefs.GUID().sizeof())
-        uuid = uuid.UUID(bytes=uuid_bytes)
+        uuid_obj = uuid.UUID(bytes=uuid_bytes)
 
-        string = str(uuid)
+        string = str(uuid_obj)
 
         self.mem_write(stringp, string.encode("utf-8"))
 

--- a/speakeasy/winenv/api/usermode/shell32.py
+++ b/speakeasy/winenv/api/usermode/shell32.py
@@ -133,6 +133,7 @@ class Shell32(api.ApiHandler):
         ptrsize = emu.get_ptr_size()
 
         split = cl.split()
+        nargs = len(split)
 
         # Get the total size we need
         size = (len(split) + 1) * ptrsize
@@ -151,7 +152,11 @@ class Shell32(api.ApiHandler):
             else:
                 s = p.encode('utf-8')
             self.mem_write(strs, s)
+
             strs += len(s)
+
+        if argc:
+            self.mem_write(argc, nargs.to_bytes(4, "little"))
 
         return buf
 

--- a/speakeasy/winenv/api/usermode/shell32.py
+++ b/speakeasy/winenv/api/usermode/shell32.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2020 FireEye, Inc. All Rights Reserved.
 
 from .. import api
+import shlex
 import speakeasy.winenv.defs.windows.windows as windefs
 import speakeasy.winenv.defs.windows.shell32 as shell32_defs
 
@@ -132,7 +133,7 @@ class Shell32(api.ApiHandler):
 
         ptrsize = emu.get_ptr_size()
 
-        split = cl.split()
+        split = shlex.split(cl)
         nargs = len(split)
 
         # Get the total size we need


### PR DESCRIPTION
- speakeasy/speakeasy.py: expose set_dyn_code_hook as a public API
- speakeasy/windows/fileman.py: `FileManager` constructor/`get_file_from_path`: changes to permit serving the actual file on disk that corresponds to the current emulated sample. This allows samples, for example, to correctly query its own file size
- speakeasy/windows/fileman.py: `get_emu_file`: if there are any decoy DLLs present, and the emulated sample asks for a memory mapping of them, Speakeasy used to just serve the default file, now it serves the correct decoy
- Added support for implicit TLS
    - speakeasy/windows/objman.py: `Thread` class: `init_tls`
    - speakeasy/windows/winemu.py: `WindowsEmulator` class: `init_tls` (same name, calls into `Thread` `init_tls`)
- speakeasy/winenv/api/usermode/kernel32.py
    - Implement `GetThreadId`
    - Fix `GetCurrentThread` so it actually return’s the current thread’s `HANDLE`
    - `WakeAllConditionVariable` stub
    - Implement `EnumProcesses`
    - Implement `GetModuleFileNameExA`
- speakeasy/winenv/api/usermode/shell32.py
    - Fix `CommandLineToArgv` so that it writes the number of args to the int pointed to by the second parameter
- speakeasy/winenv/api/usermode/rpcrt4.py
    - Implement `UuidCreate`
    - Implement `UuidToStringA`
- Unicorn's invalid instruction hook is now exposed through `add_invalid_instruction_hook` in Speakeasy