### PR TITLE
Fix a logic bug in dnsapi.DnsQuery_A

### DIFF
--- a/speakeasy/winenv/api/usermode/dnsapi.py
+++ b/speakeasy/winenv/api/usermode/dnsapi.py
@@ -59,6 +59,7 @@ class DnsApi(api.ApiHandler):
 
         pszName, wType, Options, pExtra, ppQueryResults, pReserved = argv
         rv = windefs.ERROR_INVALID_PARAMETER
+        rr = None
 
         cw = self.get_char_width(ctx)
         if pszName:


### PR DESCRIPTION
Fix a logic bug in dnsapi.DnsQuery_A where the `rr` variable was not set sometimes.
Before, I had this error: 
![image](https://user-images.githubusercontent.com/14599855/133534646-1ba5045a-03bf-4b98-9118-1c84e56fabb1.png)

This PR fixes this.