### PR TITLE
Fix for Error while calling API handler for ntdll.LdrLoadDll:

### DIFF
--- a/speakeasy/winenv/api/usermode/ntdll.py
+++ b/speakeasy/winenv/api/usermode/ntdll.py
@@ -6,6 +6,7 @@ from .. import api
 
 import speakeasy.winenv.defs.nt.ddk as ddk
 import speakeasy.winenv.defs.nt.ntoskrnl as ntos
+import speakeasy.windows.common as winemu
 
 
 class Ntdll(api.ApiHandler):
@@ -90,7 +91,7 @@ class Ntdll(api.ApiHandler):
         hmod = 0
 
         req_lib = self.read_unicode_string(Name)
-        lib = self.normalize_dll_name(req_lib)
+        lib = winemu.normalize_dll_name(req_lib)
 
         hmod = emu.load_library(lib)
 


### PR DESCRIPTION
During some normal usage I realized that the ntdll.LdrLoadDll is calling `normalize_dll_name` object referring to `self`.
But we actually do not have this object here.

The error dropped is 
```
Error while calling API handler for ntdll.LdrLoadDll
Caught error: 'Ntdll' object has no attribute 'normalize_dll_name'
```

I fixed it by applying the same calling convention seen in `/winenv/api/usermode/kernel32.py`, so adding the call through `winemu`.

From my tests it works.